### PR TITLE
Release 1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,6 @@ dependencies:
   refiner_flutter: ^[version]
 ```
 
-#### Android
-
-- Add the configuration below in your app/build.gradle file.
-
-```kotlin
-android {
-    buildFeatures {
-        dataBinding = true
-    }
-}
-```
-
 #### iOS
 
 - Run command `pod install` in your ios directory

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,11 +33,7 @@ android {
     defaultConfig {
         minSdkVersion 21
     }
-
-    dataBinding {
-        enabled = true
-    }
 }
 dependencies {
-    implementation 'io.refiner:refiner:1.3.4'
+    implementation 'io.refiner:refiner:1.3.6'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -54,9 +54,6 @@ android {
             signingConfig signingConfigs.debug
         }
     }
-    buildFeatures {
-        dataBinding = true
-    }
 }
 
 flutter {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
-  refiner_flutter: 1.3.4
+  refiner_flutter: ^1.3.6
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refiner_flutter
 description: Official Flutter wrapper for the Refiner.io Mobile SDK
-version: 1.3.4
+version: 1.3.6
 homepage: https://github.com/refiner-io/mobile-sdk-flutter
 repository: https://github.com/refiner-io/mobile-sdk-flutter
 issue_tracker: https://github.com/refiner-io/mobile-sdk-flutter/issues


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner Android SDK to version 1.3.6
2. Removes databinding usage

# How to test it

1. Run the example app
2. See the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully