### PR TITLE
Release 1.3.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
     }
 }
 dependencies {
-    implementation 'io.refiner:refiner:1.3.6'
+    implementation 'io.refiner:refiner:1.3.10'
 }

--- a/ios/refiner_flutter.podspec
+++ b/ios/refiner_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'refiner_flutter'
-  s.version          = '0.0.1'
+  s.version          = '1.3.10'
   s.summary          = 'Official Flutter wrapper for the Refiner.io Mobile SDK'
   s.description      = <<-DESC
 Official Flutter wrapper for the Refiner.io Mobile SDK
@@ -15,7 +15,7 @@ Official Flutter wrapper for the Refiner.io Mobile SDK
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RefinerSDK', "~> 1.3.4"
+  s.dependency 'RefinerSDK', "~> 1.3.10"
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refiner_flutter
 description: Official Flutter wrapper for the Refiner.io Mobile SDK
-version: 1.3.6
+version: 1.3.10
 homepage: https://github.com/refiner-io/mobile-sdk-flutter
 repository: https://github.com/refiner-io/mobile-sdk-flutter
 issue_tracker: https://github.com/refiner-io/mobile-sdk-flutter/issues


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner Android SDK to version 1.3.10

# How to test it

1. Run the example app
2. See the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully