### PR TITLE
Upgrade Native SDK versions and add onError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,12 @@ Refiner.addListener('onComplete', (args) {
     print(value);
 });   
 ```
+
+`onError` gets called when an error occurred.
+
+```dart
+Refiner.addListener('onError', (args) {
+    print('onError');
+    print(value);
+});   
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
     }
 }
 dependencies {
-    implementation 'io.refiner:refiner:1.5.5'
+    implementation 'io.refiner:refiner:1.5.6'
 }

--- a/android/src/main/java/refiner/io/flutter/refiner_flutter/RefinerFlutterPlugin.java
+++ b/android/src/main/java/refiner/io/flutter/refiner_flutter/RefinerFlutterPlugin.java
@@ -251,6 +251,14 @@ public class RefinerFlutterPlugin implements FlutterPlugin, MethodCallHandler {
             return null;
 
         });
+
+        Refiner.INSTANCE.onError((message) -> {
+            HashMap map = new HashMap();
+            map.put("message", message);
+            sendEvent("onError", map);
+            return null;
+
+        });
     }
 
     private void sendEvent(String eventName, HashMap params) {

--- a/ios/Classes/RefinerFlutterPlugin.swift
+++ b/ios/Classes/RefinerFlutterPlugin.swift
@@ -130,6 +130,10 @@ public class RefinerFlutterPlugin: NSObject, FlutterPlugin {
             let args:[String : Any?]=["formId":formId,"formElement":formElement,"progress":progress]
             self.sendEvent(eventName: "onNavigation", params:args)
         }
+        Refiner.instance.onError = { message in
+            let args:[String : Any?]=["message":message]
+            self.sendEvent(eventName: "onError", params:args)
+        }
     }
     private func sendEvent(eventName:String, params:[String : Any?]?) {
         self.channel?.invokeMethod(eventName, arguments: params)

--- a/ios/refiner_flutter.podspec
+++ b/ios/refiner_flutter.podspec
@@ -4,10 +4,10 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'refiner_flutter'
-  s.version          = '1.6.2'
-  s.summary          = 'Official Flutter wrapper for the Refiner.io Mobile SDK'
+  s.version          = '1.6.3'
+  s.summary          = 'Official Flutter wrapper for the Refiner Mobile SDK'
   s.description      = <<-DESC
-Official Flutter wrapper for the Refiner.io Mobile SDK
+Official Flutter wrapper for the Refiner Mobile SDK
                        DESC
   s.homepage         = 'https://refiner.io'
   s.license          = { :file => '../LICENSE' }
@@ -15,7 +15,7 @@ Official Flutter wrapper for the Refiner.io Mobile SDK
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RefinerSDK', "~> 1.5.5"
+  s.dependency 'RefinerSDK', "~> 1.5.6"
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/src/refiner_flutter_platform_interface.dart
+++ b/lib/src/refiner_flutter_platform_interface.dart
@@ -77,6 +77,7 @@ abstract class RefinerFlutterPlatform extends PlatformInterface {
     'onDismiss': [],
     'onClose': [],
     'onComplete': [],
+    'onError': []
   };
 
   void addListener(String name, Function(Map) callBackFunc) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refiner_flutter
-description: Official Flutter wrapper for the Refiner.io Mobile SDK
-version: 1.6.2
+description: Official Flutter wrapper for the Refiner Mobile SDK
+version: 1.6.3
 homepage: https://github.com/refiner-io/mobile-sdk-flutter
 repository: https://github.com/refiner-io/mobile-sdk-flutter
 issue_tracker: https://github.com/refiner-io/mobile-sdk-flutter/issues


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS SDK to 1.5.6 and Android SDK to 1.5.6

# How to test it

1. Run the app
2. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully