### PR TITLE
Add writeOperation param to identifyUser method and release 1.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ var userTraits = {
 await Refiner.identifyUser(userId: 'my-user-id', userTraits: userTraits);
 ```
 
+#### Advanced parameters
+
 The third parameter is for setting the `locale` of a user and is optional. The expected format is a
 two letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. When
 provided, the locale code is used for launching surveys for specific languages, as well as launching
@@ -74,6 +76,8 @@ optional [Identity Verification](https://refiner.io/docs/kb/settings/identity-ve
 signature. We recommend to use a Identify Verification signature for increased security in a
 production environment. For development purposes, you can set this value to `null`.
 
+The fifth parameter allows you to change the data storage mode for userTraits from the default "append" mode to "replace". By default, traits are appended to the existing user record—this means previously stored data will persist even if it's not included in the current payload. When set to "replace", only the traits provided in the current payload are kept. Any previously stored traits that are not included will be removed from the user object in Refiner.
+
 ```dart
 var userTraits = {
   'email': 'hello@hello.com',
@@ -81,7 +85,7 @@ var userTraits = {
   'a_date': '2022-16-04 12:00:00'
 };
 
-awaitRefiner.identifyUser(userId: 'my-user-id',userTraits: userTraits,locale: 'LOCALE',signature: 'SIGNATURE');
+awaitRefiner.identifyUser(userId: 'my-user-id',userTraits: userTraits,locale: 'LOCALE',signature: 'SIGNATURE', "append");
 ```
 
 ### Set User
@@ -92,7 +96,7 @@ In contrast to the `Identify User` method, the `Set User` method does not immedi
 
 The purpose of this alternative method is provide a way to identify users locally when the SDK is initialised but keep the number of tracked users in your Refiner account to a minimum.
 
-```kotlin
+```dart
 var userTraits = {
   'email': 'hello@hello.com',
   'a_number': 123,

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
     }
 }
 dependencies {
-    implementation 'io.refiner:refiner:1.5.6'
+    implementation 'io.refiner:refiner:1.5.7'
 }

--- a/android/src/main/java/refiner/io/flutter/refiner_flutter/RefinerFlutterPlugin.java
+++ b/android/src/main/java/refiner/io/flutter/refiner_flutter/RefinerFlutterPlugin.java
@@ -45,7 +45,7 @@ public class RefinerFlutterPlugin implements FlutterPlugin, MethodCallHandler {
                 setProject(args.get("projectId").toString());
                 break;
             case "identifyUser":
-                identifyUser(args.get("userId").toString(), (HashMap) args.get("userTraits"), (String) args.get("locale"), (String) args.get("signature"));
+                identifyUser(args.get("userId").toString(), (HashMap) args.get("userTraits"), (String) args.get("locale"), (String) args.get("signature"), (String) args.get("writeOperation"));
                 success(result);
                 break;
             case "setUser":
@@ -121,13 +121,15 @@ public class RefinerFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         }
     }
 
-    public void identifyUser(String userId, HashMap userTraits, String locale, String signature) {
+    public void identifyUser(String userId, HashMap userTraits, String locale, String signature, String writeOperation) {
         LinkedHashMap<String, Object> userTraitsMap = new LinkedHashMap<>();
         for (Object e : userTraits.keySet()) {
             userTraitsMap.put(e.toString(), userTraits.get(e.toString()));
         }
         if (userId != null) {
-            Refiner.INSTANCE.identifyUser(userId, userTraitsMap, locale, signature);
+            Refiner.INSTANCE.identifyUser(userId, userTraitsMap, locale, signature,
+                    writeOperation == null ? Refiner.WriteOperation.APPEND :
+                            Refiner.WriteOperation.valueOf(writeOperation));
         }
     }
 

--- a/ios/Classes/RefinerFlutterPlugin.swift
+++ b/ios/Classes/RefinerFlutterPlugin.swift
@@ -20,7 +20,7 @@ public class RefinerFlutterPlugin: NSObject, FlutterPlugin {
             case "setProject":
                 self.setProject(projectId: args["projectId"] as! String)
             case "identifyUser":
-                self.identifyUser(userId: args["userId"] as! String, userTraits: args["userTraits"] as! [String : NSObject]?, locale: args["locale"] as? String, signature: args["signature"] as? String)
+                self.identifyUser(userId: args["userId"] as! String, userTraits: args["userTraits"] as! [String : NSObject]?, locale: args["locale"] as? String, signature: args["signature"] as? String, writeOperation: args["writeOperation"] as? String)
             case "setUser":
                 self.setUser(userId: args["userId"] as! String, userTraits: args["userTraits"] as! [String : NSObject]?, locale: args["locale"] as? String, signature: args["signature"] as? String)
             case "trackEvent":
@@ -64,9 +64,9 @@ public class RefinerFlutterPlugin: NSObject, FlutterPlugin {
         Refiner.instance.setProject(with: projectId)
     }
     
-    public func identifyUser(userId:String, userTraits:[String : NSObject]?, locale:String?, signature:String?)  {
+    public func identifyUser(userId:String, userTraits:[String : NSObject]?, locale:String?, signature:String?, writeOperation:String?)  {
         do{
-            try Refiner.instance.identifyUser(userId: userId,userTraits: userTraits,locale: locale ,signature: signature)
+            try Refiner.instance.identifyUser(userId: userId,userTraits: userTraits,locale: locale ,signature: signature, writeOperation: writeOperation)
         } catch {
         }
     }

--- a/ios/refiner_flutter.podspec
+++ b/ios/refiner_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'refiner_flutter'
-  s.version          = '1.6.3'
+  s.version          = '1.6.4'
   s.summary          = 'Official Flutter wrapper for the Refiner Mobile SDK'
   s.description      = <<-DESC
 Official Flutter wrapper for the Refiner Mobile SDK
@@ -15,7 +15,7 @@ Official Flutter wrapper for the Refiner Mobile SDK
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RefinerSDK', "~> 1.5.6"
+  s.dependency 'RefinerSDK', "~> 1.5.8"
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/refiner_flutter.dart
+++ b/lib/refiner_flutter.dart
@@ -15,9 +15,10 @@ class Refiner {
       {required String userId,
       required Map<String, dynamic> userTraits,
       String? locale,
-      String? signature}) {
+      String? signature,
+      String? writeOperation}) {
     return RefinerFlutterPlatform.instance
-        .identifyUser(userId, userTraits, locale, signature);
+        .identifyUser(userId, userTraits, locale, signature, writeOperation);
   }
 
   static Future setUser(

--- a/lib/src/refiner_flutter_method_channel.dart
+++ b/lib/src/refiner_flutter_method_channel.dart
@@ -21,12 +21,13 @@ class MethodChannelRefinerFlutter extends RefinerFlutterPlatform {
 
   @override
   Future identifyUser(String userId, Map<String, dynamic> userTraits,
-      String? locale, String? signature) {
+      String? locale, String? signature, String? writeOperation) {
     return methodChannel.invokeMethod('identifyUser', {
       'userId': userId,
       'userTraits': userTraits,
       'locale': locale,
-      'signature': signature
+      'signature': signature,
+      'writeOperation': writeOperation
     });
   }
 

--- a/lib/src/refiner_flutter_platform_interface.dart
+++ b/lib/src/refiner_flutter_platform_interface.dart
@@ -24,7 +24,7 @@ abstract class RefinerFlutterPlatform extends PlatformInterface {
   }
 
   Future identifyUser(String userId, Map<String, dynamic> userTraits,
-      String? locale, String? signature) {
+      String? locale, String? signature, String? writeOperation) {
     throw UnimplementedError('identifyUser() has not been implemented.');
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refiner_flutter
 description: Official Flutter wrapper for the Refiner Mobile SDK
-version: 1.6.3
+version: 1.6.4
 homepage: https://github.com/refiner-io/mobile-sdk-flutter
 repository: https://github.com/refiner-io/mobile-sdk-flutter
 issue_tracker: https://github.com/refiner-io/mobile-sdk-flutter/issues


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS SDK to 1.5.8 and Android SDK to 1.5.7
2. Adds a new `writeOperation` parameter to the `identifyUser` method to control data storage mode (append vs replace)
3. Updates the Flutter plugin version to 1.6.4

# How to test it

1. Run the example app and test the `identifyUser` method with the new `writeOperation` parameter
2. Verify that both "append" and "replace" modes work correctly for user traits storage
3. Test that the upgraded native SDKs (iOS 1.5.8, Android 1.5.7) integrate properly
4. Verify that existing functionality continues to work as expected

# Acceptance criteria

* The `identifyUser` method accepts the new `writeOperation` parameter
* The upgraded native SDKs (iOS 1.5.8, Android 1.5.7) are properly integrated
* All existing functionality remains unchanged and working