### PR TITLE
Release 1.6.5

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
-  refiner_flutter: ^1.6.2
+  refiner_flutter: ^1.6.5
 
 dev_dependencies:
   flutter_test:

--- a/ios/refiner_flutter.podspec
+++ b/ios/refiner_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'refiner_flutter'
-  s.version          = '1.6.4'
+  s.version          = '1.6.5'
   s.summary          = 'Official Flutter wrapper for the Refiner Mobile SDK'
   s.description      = <<-DESC
 Official Flutter wrapper for the Refiner Mobile SDK
@@ -15,7 +15,7 @@ Official Flutter wrapper for the Refiner Mobile SDK
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'RefinerSDK', "~> 1.5.8"
+  s.dependency 'RefinerSDK', "~> 1.5.9"
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: refiner_flutter
 description: Official Flutter wrapper for the Refiner Mobile SDK
-version: 1.6.4
+version: 1.6.5
 homepage: https://github.com/refiner-io/mobile-sdk-flutter
 repository: https://github.com/refiner-io/mobile-sdk-flutter
 issue_tracker: https://github.com/refiner-io/mobile-sdk-flutter/issues


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS SDK to 1.5.9

# How to test it

1. Run the app
2. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully