### PR TITLE
Upgrade Kotlin to 2.1.20 in example app

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,6 +1,5 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4096M
 android.useAndroidX=true
-android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.8.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.20" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.20" apply false
 }
 
 include ":app"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Flutter (1.0.0)
-  - refiner_flutter (1.7.0):
+  - refiner_flutter (1.8.0):
     - Flutter
     - RefinerSDK (~> 1.7.1)
   - RefinerSDK (1.7.1)
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  refiner_flutter: b2e81f684a708e6973524a68b0deec6b75ee6055
+  refiner_flutter: 329bc87ca2bd3b0442fb87829af54141366821df
   RefinerSDK: efc3a318824fc21344b9c5aeb0d4bc365a3b1164
 
 PODFILE CHECKSUM: d55f5676cf9e97c3ce7eac0f82d01863a978e840


### PR DESCRIPTION
# What it does

Upgrades the example app's Kotlin version from 1.9.20 to 2.1.20 to align with the native Android SDK 1.7.2 (which is compiled with Kotlin 2.1.20). Also cleans up deprecated Gradle properties.

### Changes
- **Kotlin**: 1.9.20 → 2.1.20 (`example/android/settings.gradle`)
- **Gradle JVM heap**: 1536M → 4096M (`example/android/gradle.properties`)
- **Removed** deprecated `android.enableJetifier=true`

# How to test it

1. `cd example && flutter build apk --debug` — Android builds without Kotlin warnings
2. `cd example && flutter build ios --debug --simulator` — iOS builds successfully
3. Install on Android emulator — NPS survey displays
4. Install on iOS simulator — NPS survey displays

# Acceptance criteria

* Example app builds on Android without Kotlin deprecation warnings
* Example app builds on iOS
* Refiner SDK initializes and shows survey on both platforms
* No Kotlin version incompatibility errors

# Link to ticket

N/A — maintenance upgrade to match native SDK 1.7.2